### PR TITLE
Add persistent functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It also supports extended AMQP features such as queue declaration and message de
 
 The package allows you to use queue interop transport the [laravel way](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/laravel/queues.md) as well as integrates the [enqueue simple client](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/laravel/quick_tour.md#enqueue-simple-client). 
 
+To make message [persistent](https://www.rabbitmq.com/persistence-conf.html) add to Laravel Job class field `protected $persistent = true;`
 ## Resources
 
 * [Documentation](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/index.md)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It also supports extended AMQP features such as queue declaration and message de
 
 The package allows you to use queue interop transport the [laravel way](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/laravel/queues.md) as well as integrates the [enqueue simple client](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/laravel/quick_tour.md#enqueue-simple-client). 
 
-To make message [persistent](https://www.rabbitmq.com/persistence-conf.html) add to Laravel Job class field `protected $persistent = true;`
+To make message [persistent](https://www.rabbitmq.com/persistence-conf.html) add to Laravel Job class field `public $persistent = true;`
 ## Resources
 
 * [Documentation](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/index.md)

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -5,6 +5,7 @@ namespace Enqueue\LaravelQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Queue\Queue as BaseQueue;
 use Interop\Queue\PsrContext;
+use Interop\Amqp\Impl\AmqpMessage;
 
 class Queue extends BaseQueue implements QueueContract
 {
@@ -58,7 +59,7 @@ class Queue extends BaseQueue implements QueueContract
     {
         $message = $this->psrContext->createMessage($payload);
 
-        if ($message instanceof \Interop\Amqp\Impl\AmqpMessage) {
+        if ($message instanceof AmqpMessage) {
             $message->setDeliveryMode(\Interop\Amqp\AmqpMessage::DELIVERY_MODE_PERSISTENT);
         }
 
@@ -75,7 +76,7 @@ class Queue extends BaseQueue implements QueueContract
     {
         $message = $this->psrContext->createMessage($this->createPayload($job, $data));
 
-        if ($message instanceof \Interop\Amqp\Impl\AmqpMessage) {
+        if ($message instanceof AmqpMessage) {
             $message->setDeliveryMode(\Interop\Amqp\AmqpMessage::DELIVERY_MODE_PERSISTENT);
         }
 

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -24,11 +24,6 @@ class Queue extends BaseQueue implements QueueContract
     protected $psrContext;
 
     /**
-     * @var boolean
-     */
-    protected $persistent = false;
-
-    /**
      * @param PsrContext $psrContext
      * @param string     $queueName
      * @param int        $timeToRun
@@ -53,8 +48,6 @@ class Queue extends BaseQueue implements QueueContract
      */
     public function push($job, $data = '', $queue = null)
     {
-        $this->persistent = $job->persistent ?? false;
-
         return $this->pushRaw($this->createPayload($job, $data), $queue);
     }
 
@@ -65,7 +58,7 @@ class Queue extends BaseQueue implements QueueContract
     {
         $message = $this->psrContext->createMessage($payload);
 
-        if ($this->persistent) {
+        if ($message instanceof \Interop\Amqp\Impl\AmqpMessage) {
             $message->setDeliveryMode(\Interop\Amqp\AmqpMessage::DELIVERY_MODE_PERSISTENT);
         }
 
@@ -82,7 +75,7 @@ class Queue extends BaseQueue implements QueueContract
     {
         $message = $this->psrContext->createMessage($this->createPayload($job, $data));
 
-        if (isset($job->persistent) && $job->persistent) {
+        if ($message instanceof \Interop\Amqp\Impl\AmqpMessage) {
             $message->setDeliveryMode(\Interop\Amqp\AmqpMessage::DELIVERY_MODE_PERSISTENT);
         }
 


### PR DESCRIPTION
RabbitMQ has [persistent message](https://www.rabbitmq.com/persistence-conf.html)  functionality that has not been serviced. 
To use it, just add to your app/Jobs/SomeJob.php field `$persistent = true`. After that when you restart RabbitMQ message still be in a queue.