### PR TITLE
declareQueue using wrong queue object

### DIFF
--- a/src/AmqpQueue.php
+++ b/src/AmqpQueue.php
@@ -57,6 +57,6 @@ class AmqpQueue extends Queue
         $interopQueue = $this->getQueue($queue);
         $interopQueue->addFlag(\Interop\Amqp\AmqpQueue::FLAG_DURABLE);
 
-        $this->getQueueInteropContext()->declareQueue($queue);
+        $this->getQueueInteropContext()->declareQueue($interopQueue);
     }
 }


### PR DESCRIPTION
### Issue

When starting laravel worker using laravel-queue, this error is produced:
```
[2019-01-24 00:48:33] laravel.ERROR: Argument 1 passed to Enqueue\AmqpLib\AmqpContext::declareQueue() must implement interface Interop\Amqp\AmqpQueue, string given, called in /var/www/html/vendor/enqueue/laravel-queue/src/AmqpQueue.php on line 61 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Argument 1 passed to Enqueue\\AmqpLib\\AmqpContext::declareQueue() must implement interface Interop\\Amqp\\AmqpQueue, string given, called in /var/www/html/vendor/enqueue/laravel-queue/src/AmqpQueue.php on line 61 at /var/www/html/vendor/enqueue/amqp-lib/AmqpContext.php:163)
[stacktrace]
#0 /var/www/html/vendor/enqueue/laravel-queue/src/AmqpQueue.php(61): Enqueue\\AmqpLib\\AmqpContext->declareQueue('wat')
#1 /var/www/html/vendor/enqueue/laravel-queue/src/AmqpQueue.php(47): Enqueue\\LaravelQueue\\AmqpQueue->declareQueue('wat')
#2 /var/www/html/vendor/laravel/framework/src/Illuminate/Queue/Worker.php(247): Enqueue\\LaravelQueue\\AmqpQueue->pop('wat')
```
`AmqpContext->declareQueue` is expecting the `Interop\Amqp\AmqpQueue` retrieved on line 57; however, the queue name as a string is passed instead.

### Fix

Pass `$interopQueue` to `AmqpContext->declareQueue`.