### PR TITLE
Fix Worker parent parameter when driver is not interop

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -49,7 +49,7 @@ class Worker extends \Illuminate\Queue\Worker implements
         $this->interop = $this->queue instanceof Queue;
 
         if (false == $this->interop) {
-            parent::daemon($connectionName, $this->queue, $options);
+            parent::daemon($connectionName, $this->queueNames, $options);
         }
 
         $context = $this->queue->getQueueInteropContext();
@@ -76,7 +76,7 @@ class Worker extends \Illuminate\Queue\Worker implements
         $this->interop = $this->queue instanceof Queue;
 
         if (false == $this->interop) {
-            parent::daemon($connectionName, $this->queue, $options);
+            parent::daemon($connectionName, $this->queueNames, $options);
         }
 
         $context = $this->queue->getQueueInteropContext();


### PR DESCRIPTION
Laravel Worker class expects these parameters to be string with queue name(s)