### PR TITLE
Bump enqueue/* dependency versions to 0.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,15 +9,15 @@
         "illuminate/queue": "^6.0",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.7|^0.8",
-        "enqueue/enqueue": "^0.9",
-        "enqueue/dsn": "^0.9"
+        "enqueue/enqueue": "^0.10",
+        "enqueue/dsn": "^0.10"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.5",
-        "enqueue/enqueue": "^0.9",
-        "enqueue/null": "^0.9@dev",
-        "enqueue/test": "^0.9@dev",
-        "enqueue/simple-client": "^0.9@dev"
+        "enqueue/enqueue": "^0.10",
+        "enqueue/null": "^0.10@dev",
+        "enqueue/test": "^0.10@dev",
+        "enqueue/simple-client": "^0.10@dev"
     },
     "autoload": {
         "psr-4": { "Enqueue\\LaravelQueue\\": "src/" },


### PR DESCRIPTION
I'm currently unable to install `enqueue/laravel-queue` alongside `enqueue/amqp-ext`, as they have different dependency versions (`enqueue/laravel-queue` depends on `enqueue/*:0.9`, `enqueue/amqp-ext` on `enqueue/*:0.10`).

This pull request simply bumps the enqueue dependencies to match those of the others.