### PR TITLE
When using this library and if another queue driver is used, in class…

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -50,6 +50,7 @@ class Worker extends \Illuminate\Queue\Worker implements
 
         if (false == $this->interop) {
             parent::daemon($connectionName, $this->queueNames, $options);
+            return;
         }
 
         $context = $this->queue->getQueueInteropContext();
@@ -77,6 +78,7 @@ class Worker extends \Illuminate\Queue\Worker implements
 
         if (false == $this->interop) {
             parent::daemon($connectionName, $this->queueNames, $options);
+            return;
         }
 
         $context = $this->queue->getQueueInteropContext();


### PR DESCRIPTION
When using this library and if another queue driver is used, in class Worker when calling parent::demon the script must finish and we need to quit child method.