### PR TITLE
Fix running next job

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -77,7 +77,7 @@ class Worker extends \Illuminate\Queue\Worker implements
         $this->interop = $this->queue instanceof Queue;
 
         if (false == $this->interop) {
-            parent::daemon($connectionName, $this->queueNames, $options);
+            parent::runNextJob($connectionName, $this->queueNames, $options);
             return;
         }
 


### PR DESCRIPTION
When using the worker with the `--once` parameter on a non-interop queue, it calls the parent daemon method, let's fix that.﻿
