### PR TITLE
Correct queue:monitor queues sizes

### DIFF
--- a/src/AmqpQueue.php
+++ b/src/AmqpQueue.php
@@ -10,6 +10,11 @@ use Interop\Amqp\AmqpContext;
 class AmqpQueue extends Queue
 {
     /**
+     * @var int
+     */
+    protected $size = 0;
+
+    /**
      * {@inheritdoc}
      *
      * @param AmqpContext $amqpContext
@@ -17,6 +22,16 @@ class AmqpQueue extends Queue
     public function __construct(AmqpContext $amqpContext, $queueName, $timeToRun)
     {
         parent::__construct($amqpContext, $queueName, $timeToRun);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function size($queue = null)
+    {
+        $this->declareQueue($queue);
+
+        return $this->size;
     }
 
     /**
@@ -57,6 +72,6 @@ class AmqpQueue extends Queue
         $interopQueue = $this->getQueue($queue);
         $interopQueue->addFlag(\Interop\Amqp\AmqpQueue::FLAG_DURABLE);
 
-        $this->getQueueInteropContext()->declareQueue($interopQueue);
+        $this->size = $this->getQueueInteropContext()->declareQueue($interopQueue);
     }
 }


### PR DESCRIPTION
Implementing this function allows for using new Laravel queue feature: [queue:monitor](https://laravel.com/docs/8.x/queues#monitoring-your-queues)

Without these changes, all queues are 0 size (from [`Enqueue\LaravelQueue\Queue`](https://github.com/php-enqueue/laravel-queue/blob/master/src/Queue.php#L44))

We are getting queue size anyway with `declareQueue`.
I am just storing it for `size` function override.