### PR TITLE
Add support for Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1",
-        "illuminate/queue": "^6.0|^7.0|^8.0",
+        "illuminate/queue": "^6.0|^7.0|^8.0|^9.0",
         "queue-interop/amqp-interop": "^0.8",
         "queue-interop/queue-interop": "^0.7|^0.8",
         "enqueue/enqueue": "^0.10",


### PR DESCRIPTION
Add Laravel 9 to composer. No additional changes needed for Laravel 8 to 9 migration.