### PR TITLE
Fix worker compatibility with Laravel v9.42

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -157,7 +157,7 @@ class Worker extends \Illuminate\Queue\Worker implements
         }
     }
 
-    public function stop($status = 0)
+    public function stop($status = 0, $options = null)
     {
         if ($this->interop) {
             $this->stopped = true;
@@ -165,7 +165,7 @@ class Worker extends \Illuminate\Queue\Worker implements
             return;
         }
 
-        parent::stop($status);
+        parent::stop($status, $options);
     }
 
     public function setExtensions(array $extensions): self


### PR DESCRIPTION
After recent Laravel update to version v9.42.0 - laravel/framework#45120 - worker stopped working due to worker's stop function being incompatible with parent.
