### PR TITLE
Fix "command defined in ....\SetupBrokerCommand" cannot have an empty name and configure() must be compatible with Enqueue\Symfony\Client\SetupBrokerCommand::configure(): void

### DIFF
--- a/src/Command/ConsumeCommand.php
+++ b/src/Command/ConsumeCommand.php
@@ -3,7 +3,9 @@ namespace Enqueue\LaravelQueue\Command;
 
 use Enqueue\SimpleClient\SimpleClient;
 use Enqueue\Symfony\Client\SimpleConsumeCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'enqueue:consume')]
 class ConsumeCommand extends SimpleConsumeCommand
 {
     public function __construct(SimpleClient $client)

--- a/src/Command/ProduceCommand.php
+++ b/src/Command/ProduceCommand.php
@@ -3,7 +3,9 @@ namespace Enqueue\LaravelQueue\Command;
 
 use Enqueue\SimpleClient\SimpleClient;
 use Enqueue\Symfony\Client\SimpleProduceCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'enqueue:produce')]
 class ProduceCommand extends SimpleProduceCommand
 {
     public function __construct(SimpleClient $client)

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -3,7 +3,9 @@ namespace Enqueue\LaravelQueue\Command;
 
 use Enqueue\SimpleClient\SimpleClient;
 use Enqueue\Symfony\Client\SimpleRoutesCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'enqueue:routes')]
 class RoutesCommand extends SimpleRoutesCommand
 {
     public function __construct(SimpleClient $client)

--- a/src/Command/SetupBrokerCommand.php
+++ b/src/Command/SetupBrokerCommand.php
@@ -10,11 +10,4 @@ class SetupBrokerCommand extends SimpleSetupBrokerCommand
     {
         parent::__construct($client->getDriver());
     }
-
-    protected function configure()
-    {
-        parent::configure();
-        
-        $this->setName('enqueue:setup-broker');
-    }
 }

--- a/src/Command/SetupBrokerCommand.php
+++ b/src/Command/SetupBrokerCommand.php
@@ -5,7 +5,7 @@ use Enqueue\SimpleClient\SimpleClient;
 use Enqueue\Symfony\Client\SimpleSetupBrokerCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand('enqueue:setup-broker')]
+#[AsCommand(name: 'enqueue:setup-broker')]
 class SetupBrokerCommand extends SimpleSetupBrokerCommand
 {
     public function __construct(SimpleClient $client)

--- a/src/Command/SetupBrokerCommand.php
+++ b/src/Command/SetupBrokerCommand.php
@@ -3,7 +3,9 @@ namespace Enqueue\LaravelQueue\Command;
 
 use Enqueue\SimpleClient\SimpleClient;
 use Enqueue\Symfony\Client\SimpleSetupBrokerCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand('enqueue:setup-broker')]
 class SetupBrokerCommand extends SimpleSetupBrokerCommand
 {
     public function __construct(SimpleClient $client)


### PR DESCRIPTION
Hey, its me again.

I created this PR in order to fix all Laravel Commands not inheriting the Symfony Attribute AsCommand.

I also rollbacked the last [PR ](https://github.com/php-enqueue/laravel-queue/pull/31) as it was causing another error.

Both things are fixed in this PR

Thanks!